### PR TITLE
[SNK] add game over state and collision

### DIFF
--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -9,6 +9,7 @@ namespace STR_CONST
 	const std::string YOUR_TURN = "YOUR TURN";
 	const std::string OPPONENT_TURN = "OPPONENT TURN";
 	const std::string GAME_FINISH = "GAME FINISH!";
+	const std::string GAME_OVER = "GAME OVER!";
 	const std::string RESTART_GAME = "RESTART GAME";
 	const std::string YOU_LOSE = "YOU LOSE";
 	const std::string YOU_WIN = "YOU WIN";

--- a/src/snake.cpp
+++ b/src/snake.cpp
@@ -14,6 +14,10 @@ Snake::Snake(sf::RenderWindow& wnd)
 		Board::TileType::Empty
 	),
 	txtTitle("SNAKE", 18, sf::Color::White, sf::Vector2f(0.0f, 0.0f), window),
+	txtEndGame(STR_CONST::GAME_OVER, 24, sf::Color::White, sf::Vector2f(
+		window.getSize().x / 2,
+		window.getSize().y / 2
+	), window),
 	tileState(TILE_STATE_SIZE),
 	gen(rd()),
 	xDist(0, GRID_WIDTH - 1),
@@ -155,7 +159,9 @@ void Snake::Draw()
 	}
 	else
 	{
-		// TODO: draw game over screen and final score
+		txtEndGame.Draw();
+
+		// TODO: draw final score
 		// TODO: add button to restart game
 	}
 }

--- a/src/snake.hpp
+++ b/src/snake.hpp
@@ -45,6 +45,7 @@ private:
 	Board board;
 	sf::RectangleShape rectPlayArea;
 	UI::Text txtTitle;
+	UI::Text txtEndGame;
 
 	float movePeriod = 0.4f;
 	float movePeriodMin = 0.1f;


### PR DESCRIPTION
**Changes** :
- `SNK` `feat` add game over state and screen
- `SNK` `feat` add game over condition when collide with wall
- `SNK` `feat` add game over condition when collide with itself 